### PR TITLE
bugfix in format_recur_byday: add comparison to empty string

### DIFF
--- a/viewical
+++ b/viewical
@@ -145,9 +145,9 @@ def format_recur_byday(weekdaynum):
     if match is None or match.group(3) not in DAY_NAMES:
         return '[ERROR: failed to parse "BYDAY={}"]'.format(weekdaynum)
     day = DAY_NAMES[match.group(3)]
-    if match.group(2) is None:
+    if match.group(2) is None or match.group(2) == "":
         return day
-    if match.group(1) is None:
+    if match.group(1) is None or match.group(1) == "":
         sign = '+'
     else:
         sign = match.group(1)


### PR DESCRIPTION
If an RRULE in an EVENT contains a BYDAY Element without a number before the Day the script fails.
e.g. `RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,TH,FR;WKST=MO` fails

Reason in function format_recur_byday(weekdaynum):
The call `match = re.search(r'^([+-]?)(\d*)(..)$', weekdaynum)` returns an empty string if an element (in this case a number) can't be mached and not None.
So `match.group(2)` returns an empty string and not None.