### PR TITLE
Mutt-ical shows now the comment of a calender event

### DIFF
--- a/viewical
+++ b/viewical
@@ -4,6 +4,7 @@ import datetime
 import os
 import re
 import sys
+import textwrap
 
 import icalendar  # https://pypi.python.org/pypi/icalendar
 import pytz  # https://pypi.python.org/pypi/pytz
@@ -194,8 +195,7 @@ def handle_event_component_dtstart(event):
             # We have an end date and time.
             if dtstart.date() == dtend.date():
                 # Start end end times are on the same day.
-                # This is a common occurence, so let's format things in a
-                # friendly way.
+                # This is a common occurence, so let's format things in a friendly way.
                 print("Date:      %s" % format_date(dtstart))
                 print("Starts:    %s" % format_time(dtstart))
                 print("Ends:      %s" % format_time(dtend))
@@ -305,9 +305,17 @@ def handle_event_vevent(event):
 
     if 'DESCRIPTION' in event:
         print("Description:")
-        # If the encode() call isn't there, print() will choke on anything that
-        # isn't ASCII.
+        # If the encode() call isn't there, print() will choke on anything that isn't ASCII.
         print(event['DESCRIPTION'])
+
+    if 'COMMENT' in event:
+        print()
+        print('Comment:   ', end='')
+        comment = event['COMMENT']
+        comment = textwrap.fill(comment, width=96, replace_whitespace=False, drop_whitespace=False)
+        comment = textwrap.indent(comment, '           ')
+        print(comment[11:])
+
     print()
 
 

--- a/viewical
+++ b/viewical
@@ -308,12 +308,6 @@ def handle_event_vevent(event):
         # If the encode() call isn't there, print() will choke on anything that
         # isn't ASCII.
         print(event['DESCRIPTION'])
-
-    if 'COMMENT' in event:
-        print()
-        print("Comment:")
-        print(event['COMMENT'])
-
     print()
 
 

--- a/viewical
+++ b/viewical
@@ -250,13 +250,15 @@ def handle_event_rrule(event):
         if len(rrule['BYDAY']) == 1:
             days = 'on %s' % format_recur_byday(rrule['BYDAY'][0])
         elif len(rrule['BYDAY']) == 2:
-            days = 'on %s and %s' % (
+            days = 'on {} and {}'.format(
                 format_recur_byday(rrule['BYDAY'][0]),
-                format_recur_byday(rrule['BYDAY'][1])
+                format_recur_byday(rrule['BYDAY'][1]),
             )
         elif len(rrule['BYDAY']) >= 3:
-            days = 'on %s, and %s' % (', '.join(format_recur_byday(d) for d in rrule['BYDAY'][:-1]),
-                                      format_recur_byday(rrule['BYDAY'][-1]))
+            days = 'on {}, and {}'.format(
+                ', '.join(format_recur_byday(d) for d in rrule['BYDAY'][:-1]),
+                format_recur_byday(rrule['BYDAY'][-1]),
+            )
     if 'COUNT' in rrule:
         count = 'for %s %s' % (rrule['COUNT'][0], freq_unit + 's')
     if 'UNTIL' in rrule:

--- a/viewical
+++ b/viewical
@@ -6,12 +6,12 @@ import re
 import sys
 
 import icalendar  # https://pypi.python.org/pypi/icalendar
-import pytz       # https://pypi.python.org/pypi/pytz
-import tzlocal    # https://pypi.python.org/pypi/tzlocal
+import pytz  # https://pypi.python.org/pypi/pytz
+import tzlocal  # https://pypi.python.org/pypi/tzlocal
 
 TIME_FORMAT = '%-I:%M %P'
 DATE_FORMAT = '%A, %B %-d, %Y'
-DATETIME_FORMAT = "%s %s" % (DATE_FORMAT , TIME_FORMAT)
+DATETIME_FORMAT = "%s %s" % (DATE_FORMAT, TIME_FORMAT)
 
 FREQ_UNITS = {
     'SECONDLY': 'second',
@@ -59,12 +59,14 @@ def ordinal(integer):
         return '{}rd'.format(integer)
     else:
         return '{}th'.format(integer)
-                
+
+
 def get_dtend(event):
     if 'DTEND' in event:
         return event['DTEND'].dt
     else:
         return None
+
 
 def localize(dt):
     """Take a datetime in an arbitrary timezone and return it in the local
@@ -74,6 +76,7 @@ def localize(dt):
         return dt.astimezone(tz)
     else:
         return tz.localize(dt)
+
 
 def format_time(dt):
     dtlocal = localize(dt)
@@ -85,6 +88,7 @@ def format_time(dt):
     else:
         return fmt
 
+
 def format_date(dt):
     if isinstance(dt, datetime.datetime):
         dtlocal = localize(dt)
@@ -92,9 +96,11 @@ def format_date(dt):
         dtlocal = dt
     return dtlocal.strftime(DATE_FORMAT)
 
+
 def format_datetime(dt):
     dtlocal = localize(dt)
     return dtlocal.strftime(DATETIME_FORMAT)
+
 
 def format_person(person):
     if 'ROLE' in person.params:
@@ -140,6 +146,7 @@ def format_person(person):
         display_name = email_address
     return display_status + display_name
 
+
 def format_recur_byday(weekdaynum):
     match = re.search(r'^([+-]?)(\d*)(..)$', weekdaynum)
     if match is None or match.group(3) not in DAY_NAMES:
@@ -156,135 +163,144 @@ def format_recur_byday(weekdaynum):
     if sign == '-':
         nth = '-' + nth
     return 'the {} {}'.format(nth, day)
-        
 
-cal = icalendar.Calendar.from_ical(sys.stdin.read())
-if 'METHOD' in cal:
-    if cal['METHOD'] == 'PUBLISH':
-        print('=== Publication ===')
-    elif cal['METHOD'] == 'REQUEST':
-        print('=== Reply Requested ===')
-    elif cal['METHOD'] == 'REPLY':
-        print('=== Response to Earlier Request ===')
-    elif cal['METHOD'] == 'ADD':
-        print('=== Request to Add a Calendar Entry ===')
-    elif cal['METHOD'] == 'CANCEL':
-        print('=== Cancellation ===')
-    elif cal['METHOD'] == 'REFRESH':
-        print('=== Request for Updated Information ===')
-    elif cal['METHOD'] == 'COUNTER':
-        print('=== Response to Earlier Request with Changes ===')
-    elif cal['METHOD'] == 'DECLINECOUNTER':
-        print('=== Denial of Request for Changes to Earlier Proposal ===')
-    print()
 
-for event in cal.subcomponents:
-    if event.name == 'VEVENT':
-        if 'CLASS' in event and event['CLASS'] != 'PUBLIC':
-            print("Classification: %s" % event['CLASS'])
-        if 'STATUS' in event and event['STATUS'] != 'CONFIRMED':
-            print("Status:    %s" % event['STATUS'])
-        if 'ORGANIZER' in event:
-            print("Organizer: %s" % format_person(event['ORGANIZER']))
-        if 'SUMMARY' in event:
-            print("Event:     %s" % event['SUMMARY'])
-        elif 'UID' in event:
-            print('UID:       %s' % event['UID'])
-
-        if 'DTSTART' in event:
-            dtstart = event['DTSTART'].dt
-            dtend = get_dtend(event)
-            if isinstance(dtstart, datetime.datetime):
-                # We have time information.
-                if dtend:
-                    # We have an end date and time.
-                    if dtstart.date() == dtend.date():
-                        # Start end end times are on the same day.
-                        # This is a common occurence, so let's format things in a
-                        # friendly way.
-                        print("Date:      %s" % format_date(dtstart))
-                        print("Starts:    %s" % format_time(dtstart))
-                        print("Ends:      %s" % format_time(dtend))
-                    else:
-                        # Start and end times are on different days.
-                        print("Starts:    %s" % format_datetime(dtstart))
-                        print("Ends:      %s" % format_datetime(dtend))
-                else:
-                    # No end date/time.
-                    print("Starts:    %s" % format_datetime(dtstart))
-            else:
-                # We have no time information.
-                if dtend and dtstart != dtend:
-                    # There's an end date and it's different from the start date.
-                    print("Starts:    %s" % format_date(dtstart))
-                    print("Ends:      %s" % format_date(dtend))
-                else:
-                    # Either starts and ends on the same day or there's no end date.
-                    print("Date:      %s" % format_date(dtstart))
-
-        if 'RRULE' in event:
-            rrule = event['RRULE']
-            interval = ""
-            freq = ""
-            days = ""
-            count = ""
-            until = ""
-
-            if 'INTERVAL' in rrule:
-                try:
-                    interval_num = int(rrule['INTERVAL'][0])
-                    if interval_num == 1:
-                        interval = ''
-                    elif interval_num == 2:
-                        interval = 'other '
-                    else:
-                        interval = ordinal(interval_num) + ' '
-                except ValueError:
-                    interval = rrule['INTERVAL'][0]
-            if 'FREQ' in rrule:
-                if rrule['FREQ'][0] in FREQ_UNITS:
-                    freq_unit = FREQ_UNITS[rrule['FREQ'][0]]
-                    freq = 'Every %s%s' % (interval, freq_unit)
-                else:
-                    freq_unit = rrule['FREQ'][0][:-2].lower()
-                    freq = '%s, with an interval of %s' % (rrule['FREQ'][0], rrule['INTERVAL'])
-            else:
-                freq_unit = 'interval'
-                freq = 'Every <unknown interval>'
-            if 'BYDAY' in rrule:
-                if len(rrule['BYDAY']) == 1:
-                    days = 'on %s' % format_recur_byday(rrule['BYDAY'][0])
-                elif len(rrule['BYDAY']) == 2:
-                    days = 'on %s and %s' % (format_recur_byday(rrule['BYDAY'][0]), format_recur_byday(rrule['BYDAY'][1]))
-                elif len(rrule['BYDAY']) >= 3:
-                    days = 'on %s, and %s' % (', '.join(format_recur_byday(d) for d in rrule['BYDAY'][:-1]), format_recur_byday(rrule['BYDAY'][-1]))
-            if 'COUNT' in rrule:
-                count = 'for %s %s' % (rrule['COUNT'][0], freq_unit + 's')
-            if 'UNTIL' in rrule:
-                if isinstance(rrule['UNTIL'][0], datetime.datetime):
-                    until = "until %s" % format_datetime(rrule['UNTIL'][0])
-                else:
-                    until = "until %s" % format_date(rrule['UNTIL'][0])
-
-            params = [x for x in [freq, days, count, until] if (x and len(x) > 0)]
-            print("Recurs:    %s" % ' '.join(params))
-
-        if 'URL' in event:
-            print("URL:       %s" % event['URL'])
-        if 'LOCATION' in event:
-            print("Location:  %s" % event['LOCATION'])
-        if 'CONTACT' in event:
-            print("Contact:   %s" % event['CONTACT'])
-        if 'ATTENDEE' in event:
-            if isinstance(event['ATTENDEE'], list):
-                print("Attendees: %s" % format_person(event['ATTENDEE'][0]))
-                for attendee in event['ATTENDEE'][1:]:
-                    print("           %s" % format_person(attendee))
-            else:
-                print("Attendee:  %s" % format_person(event['ATTENDEE']))
-        if 'DESCRIPTION' in event:
-            print("Description:")
-            # If the encode() call isn't there, print() will choke on anything that
-            # isn't ASCII.
-            print(event['DESCRIPTION'])
+def main():
+    cal = icalendar.Calendar.from_ical(sys.stdin.read())
+    if 'METHOD' in cal:
+        if cal['METHOD'] == 'PUBLISH':
+            print('=== Publication ===')
+        elif cal['METHOD'] == 'REQUEST':
+            print('=== Reply Requested ===')
+        elif cal['METHOD'] == 'REPLY':
+            print('=== Response to Earlier Request ===')
+        elif cal['METHOD'] == 'ADD':
+            print('=== Request to Add a Calendar Entry ===')
+        elif cal['METHOD'] == 'CANCEL':
+            print('=== Cancellation ===')
+        elif cal['METHOD'] == 'REFRESH':
+            print('=== Request for Updated Information ===')
+        elif cal['METHOD'] == 'COUNTER':
+            print('=== Response to Earlier Request with Changes ===')
+        elif cal['METHOD'] == 'DECLINECOUNTER':
+            print('=== Denial of Request for Changes to Earlier Proposal ===')
         print()
+
+    for event in cal.subcomponents:
+        if event.name == 'VEVENT':
+            if 'CLASS' in event and event['CLASS'] != 'PUBLIC':
+                print("Classification: %s" % event['CLASS'])
+            if 'STATUS' in event and event['STATUS'] != 'CONFIRMED':
+                print("Status:    %s" % event['STATUS'])
+            if 'ORGANIZER' in event:
+                print("Organizer: %s" % format_person(event['ORGANIZER']))
+            if 'SUMMARY' in event:
+                print("Event:     %s" % event['SUMMARY'])
+            elif 'UID' in event:
+                print('UID:       %s' % event['UID'])
+
+            if 'DTSTART' in event:
+                dtstart = event['DTSTART'].dt
+                dtend = get_dtend(event)
+                if isinstance(dtstart, datetime.datetime):
+                    # We have time information.
+                    if dtend:
+                        # We have an end date and time.
+                        if dtstart.date() == dtend.date():
+                            # Start end end times are on the same day.
+                            # This is a common occurence, so let's format things in a
+                            # friendly way.
+                            print("Date:      %s" % format_date(dtstart))
+                            print("Starts:    %s" % format_time(dtstart))
+                            print("Ends:      %s" % format_time(dtend))
+                        else:
+                            # Start and end times are on different days.
+                            print("Starts:    %s" % format_datetime(dtstart))
+                            print("Ends:      %s" % format_datetime(dtend))
+                    else:
+                        # No end date/time.
+                        print("Starts:    %s" % format_datetime(dtstart))
+                else:
+                    # We have no time information.
+                    if dtend and dtstart != dtend:
+                        # There's an end date and it's different from the start date.
+                        print("Starts:    %s" % format_date(dtstart))
+                        print("Ends:      %s" % format_date(dtend))
+                    else:
+                        # Either starts and ends on the same day or there's no end date.
+                        print("Date:      %s" % format_date(dtstart))
+
+            if 'RRULE' in event:
+                rrule = event['RRULE']
+                interval = ""
+                freq = ""
+                days = ""
+                count = ""
+                until = ""
+
+                if 'INTERVAL' in rrule:
+                    try:
+                        interval_num = int(rrule['INTERVAL'][0])
+                        if interval_num == 1:
+                            interval = ''
+                        elif interval_num == 2:
+                            interval = 'other '
+                        else:
+                            interval = ordinal(interval_num) + ' '
+                    except ValueError:
+                        interval = rrule['INTERVAL'][0]
+                if 'FREQ' in rrule:
+                    if rrule['FREQ'][0] in FREQ_UNITS:
+                        freq_unit = FREQ_UNITS[rrule['FREQ'][0]]
+                        freq = 'Every %s%s' % (interval, freq_unit)
+                    else:
+                        freq_unit = rrule['FREQ'][0][:-2].lower()
+                        freq = '%s, with an interval of %s' % (rrule['FREQ'][0], rrule['INTERVAL'])
+                else:
+                    freq_unit = 'interval'
+                    freq = 'Every <unknown interval>'
+                if 'BYDAY' in rrule:
+                    if len(rrule['BYDAY']) == 1:
+                        days = 'on %s' % format_recur_byday(rrule['BYDAY'][0])
+                    elif len(rrule['BYDAY']) == 2:
+                        days = 'on %s and %s' % (
+                            format_recur_byday(rrule['BYDAY'][0]),
+                            format_recur_byday(rrule['BYDAY'][1])
+                        )
+                    elif len(rrule['BYDAY']) >= 3:
+                        days = 'on %s, and %s' % (', '.join(format_recur_byday(d) for d in rrule['BYDAY'][:-1]),
+                                                  format_recur_byday(rrule['BYDAY'][-1]))
+                if 'COUNT' in rrule:
+                    count = 'for %s %s' % (rrule['COUNT'][0], freq_unit + 's')
+                if 'UNTIL' in rrule:
+                    if isinstance(rrule['UNTIL'][0], datetime.datetime):
+                        until = "until %s" % format_datetime(rrule['UNTIL'][0])
+                    else:
+                        until = "until %s" % format_date(rrule['UNTIL'][0])
+
+                params = [x for x in [freq, days, count, until] if (x and len(x) > 0)]
+                print("Recurs:    %s" % ' '.join(params))
+
+            if 'URL' in event:
+                print("URL:       %s" % event['URL'])
+            if 'LOCATION' in event:
+                print("Location:  %s" % event['LOCATION'])
+            if 'CONTACT' in event:
+                print("Contact:   %s" % event['CONTACT'])
+            if 'ATTENDEE' in event:
+                if isinstance(event['ATTENDEE'], list):
+                    print("Attendees: %s" % format_person(event['ATTENDEE'][0]))
+                    for attendee in event['ATTENDEE'][1:]:
+                        print("           %s" % format_person(attendee))
+                else:
+                    print("Attendee:  %s" % format_person(event['ATTENDEE']))
+            if 'DESCRIPTION' in event:
+                print("Description:")
+                # If the encode() call isn't there, print() will choke on anything that
+                # isn't ASCII.
+                print(event['DESCRIPTION'])
+            print()
+
+
+if __name__ == '__main__':
+    main()

--- a/viewical
+++ b/viewical
@@ -185,7 +185,7 @@ def print_method(method):
     print()
 
 
-def handle_event_dtstart(event):
+def handle_event_component_dtstart(event):
     dtstart = event['DTSTART'].dt
     dtend = get_dtend(event)
     if isinstance(dtstart, datetime.datetime):
@@ -217,7 +217,7 @@ def handle_event_dtstart(event):
             print("Date:      %s" % format_date(dtstart))
 
 
-def handle_event_rrule(event):
+def handle_event_component_rrule(event):
     rrule = event['RRULE']
     interval = ""
     freq = ""
@@ -271,6 +271,52 @@ def handle_event_rrule(event):
     print("Recurs:    %s" % ' '.join(params))
 
 
+def handle_event_vevent(event):
+    if 'CLASS' in event and event['CLASS'] != 'PUBLIC':
+        print("Classification: %s" % event['CLASS'])
+    if 'STATUS' in event and event['STATUS'] != 'CONFIRMED':
+        print("Status:    %s" % event['STATUS'])
+    if 'ORGANIZER' in event:
+        print("Organizer: %s" % format_person(event['ORGANIZER']))
+
+    if 'SUMMARY' in event:
+        print("Event:     %s" % event['SUMMARY'])
+    elif 'UID' in event:
+        print('UID:       %s' % event['UID'])
+
+    if 'DTSTART' in event:
+        handle_event_component_dtstart(event)
+    if 'RRULE' in event:
+        handle_event_component_rrule(event)
+    if 'URL' in event:
+        print("URL:       %s" % event['URL'])
+    if 'LOCATION' in event:
+        print("Location:  %s" % event['LOCATION'])
+    if 'CONTACT' in event:
+        print("Contact:   %s" % event['CONTACT'])
+
+    if 'ATTENDEE' in event:
+        if isinstance(event['ATTENDEE'], list):
+            print("Attendees: %s" % format_person(event['ATTENDEE'][0]))
+            for attendee in event['ATTENDEE'][1:]:
+                print("           %s" % format_person(attendee))
+        else:
+            print("Attendee:  %s" % format_person(event['ATTENDEE']))
+
+    if 'DESCRIPTION' in event:
+        print("Description:")
+        # If the encode() call isn't there, print() will choke on anything that
+        # isn't ASCII.
+        print(event['DESCRIPTION'])
+
+    if 'COMMENT' in event:
+        print()
+        print("Comment:")
+        print(event['COMMENT'])
+
+    print()
+
+
 def main():
     cal = icalendar.Calendar.from_ical(sys.stdin.read())
     if 'METHOD' in cal:
@@ -278,42 +324,7 @@ def main():
 
     for event in cal.subcomponents:
         if event.name == 'VEVENT':
-            if 'CLASS' in event and event['CLASS'] != 'PUBLIC':
-                print("Classification: %s" % event['CLASS'])
-            if 'STATUS' in event and event['STATUS'] != 'CONFIRMED':
-                print("Status:    %s" % event['STATUS'])
-            if 'ORGANIZER' in event:
-                print("Organizer: %s" % format_person(event['ORGANIZER']))
-
-            if 'SUMMARY' in event:
-                print("Event:     %s" % event['SUMMARY'])
-            elif 'UID' in event:
-                print('UID:       %s' % event['UID'])
-
-            if 'DTSTART' in event:
-                handle_event_dtstart(event)
-            if 'RRULE' in event:
-                handle_event_rrule(event)
-            if 'URL' in event:
-                print("URL:       %s" % event['URL'])
-            if 'LOCATION' in event:
-                print("Location:  %s" % event['LOCATION'])
-            if 'CONTACT' in event:
-                print("Contact:   %s" % event['CONTACT'])
-            if 'ATTENDEE' in event:
-                if isinstance(event['ATTENDEE'], list):
-                    print("Attendees: %s" % format_person(event['ATTENDEE'][0]))
-                    for attendee in event['ATTENDEE'][1:]:
-                        print("           %s" % format_person(attendee))
-                else:
-                    print("Attendee:  %s" % format_person(event['ATTENDEE']))
-
-            if 'DESCRIPTION' in event:
-                print("Description:")
-                # If the encode() call isn't there, print() will choke on anything that
-                # isn't ASCII.
-                print(event['DESCRIPTION'])
-            print()
+            handle_event_vevent(event)
 
 
 if __name__ == '__main__':

--- a/viewical
+++ b/viewical
@@ -165,26 +165,114 @@ def format_recur_byday(weekdaynum):
     return 'the {} {}'.format(nth, day)
 
 
+def print_method(method):
+    if method == 'PUBLISH':
+        print('=== Publication ===')
+    elif method == 'REQUEST':
+        print('=== Reply Requested ===')
+    elif method == 'REPLY':
+        print('=== Response to Earlier Request ===')
+    elif method == 'ADD':
+        print('=== Request to Add a Calendar Entry ===')
+    elif method == 'CANCEL':
+        print('=== Cancellation ===')
+    elif method == 'REFRESH':
+        print('=== Request for Updated Information ===')
+    elif method == 'COUNTER':
+        print('=== Response to Earlier Request with Changes ===')
+    elif method == 'DECLINECOUNTER':
+        print('=== Denial of Request for Changes to Earlier Proposal ===')
+    print()
+
+
+def handle_event_dtstart(event):
+    dtstart = event['DTSTART'].dt
+    dtend = get_dtend(event)
+    if isinstance(dtstart, datetime.datetime):
+        # We have time information.
+        if dtend:
+            # We have an end date and time.
+            if dtstart.date() == dtend.date():
+                # Start end end times are on the same day.
+                # This is a common occurence, so let's format things in a
+                # friendly way.
+                print("Date:      %s" % format_date(dtstart))
+                print("Starts:    %s" % format_time(dtstart))
+                print("Ends:      %s" % format_time(dtend))
+            else:
+                # Start and end times are on different days.
+                print("Starts:    %s" % format_datetime(dtstart))
+                print("Ends:      %s" % format_datetime(dtend))
+        else:
+            # No end date/time.
+            print("Starts:    %s" % format_datetime(dtstart))
+    else:
+        # We have no time information.
+        if dtend and dtstart != dtend:
+            # There's an end date and it's different from the start date.
+            print("Starts:    %s" % format_date(dtstart))
+            print("Ends:      %s" % format_date(dtend))
+        else:
+            # Either starts and ends on the same day or there's no end date.
+            print("Date:      %s" % format_date(dtstart))
+
+
+def handle_event_rrule(event):
+    rrule = event['RRULE']
+    interval = ""
+    freq = ""
+    days = ""
+    count = ""
+    until = ""
+
+    if 'INTERVAL' in rrule:
+        try:
+            interval_num = int(rrule['INTERVAL'][0])
+            if interval_num == 1:
+                interval = ''
+            elif interval_num == 2:
+                interval = 'other '
+            else:
+                interval = ordinal(interval_num) + ' '
+        except ValueError:
+            interval = rrule['INTERVAL'][0]
+    if 'FREQ' in rrule:
+        if rrule['FREQ'][0] in FREQ_UNITS:
+            freq_unit = FREQ_UNITS[rrule['FREQ'][0]]
+            freq = 'Every %s%s' % (interval, freq_unit)
+        else:
+            freq_unit = rrule['FREQ'][0][:-2].lower()
+            freq = '%s, with an interval of %s' % (rrule['FREQ'][0], rrule['INTERVAL'])
+    else:
+        freq_unit = 'interval'
+        freq = 'Every <unknown interval>'
+    if 'BYDAY' in rrule:
+        if len(rrule['BYDAY']) == 1:
+            days = 'on %s' % format_recur_byday(rrule['BYDAY'][0])
+        elif len(rrule['BYDAY']) == 2:
+            days = 'on %s and %s' % (
+                format_recur_byday(rrule['BYDAY'][0]),
+                format_recur_byday(rrule['BYDAY'][1])
+            )
+        elif len(rrule['BYDAY']) >= 3:
+            days = 'on %s, and %s' % (', '.join(format_recur_byday(d) for d in rrule['BYDAY'][:-1]),
+                                      format_recur_byday(rrule['BYDAY'][-1]))
+    if 'COUNT' in rrule:
+        count = 'for %s %s' % (rrule['COUNT'][0], freq_unit + 's')
+    if 'UNTIL' in rrule:
+        if isinstance(rrule['UNTIL'][0], datetime.datetime):
+            until = "until %s" % format_datetime(rrule['UNTIL'][0])
+        else:
+            until = "until %s" % format_date(rrule['UNTIL'][0])
+
+    params = [x for x in [freq, days, count, until] if (x and len(x) > 0)]
+    print("Recurs:    %s" % ' '.join(params))
+
+
 def main():
     cal = icalendar.Calendar.from_ical(sys.stdin.read())
     if 'METHOD' in cal:
-        if cal['METHOD'] == 'PUBLISH':
-            print('=== Publication ===')
-        elif cal['METHOD'] == 'REQUEST':
-            print('=== Reply Requested ===')
-        elif cal['METHOD'] == 'REPLY':
-            print('=== Response to Earlier Request ===')
-        elif cal['METHOD'] == 'ADD':
-            print('=== Request to Add a Calendar Entry ===')
-        elif cal['METHOD'] == 'CANCEL':
-            print('=== Cancellation ===')
-        elif cal['METHOD'] == 'REFRESH':
-            print('=== Request for Updated Information ===')
-        elif cal['METHOD'] == 'COUNTER':
-            print('=== Response to Earlier Request with Changes ===')
-        elif cal['METHOD'] == 'DECLINECOUNTER':
-            print('=== Denial of Request for Changes to Earlier Proposal ===')
-        print()
+        print_method(cal['METHOD'])
 
     for event in cal.subcomponents:
         if event.name == 'VEVENT':
@@ -194,93 +282,16 @@ def main():
                 print("Status:    %s" % event['STATUS'])
             if 'ORGANIZER' in event:
                 print("Organizer: %s" % format_person(event['ORGANIZER']))
+
             if 'SUMMARY' in event:
                 print("Event:     %s" % event['SUMMARY'])
             elif 'UID' in event:
                 print('UID:       %s' % event['UID'])
 
             if 'DTSTART' in event:
-                dtstart = event['DTSTART'].dt
-                dtend = get_dtend(event)
-                if isinstance(dtstart, datetime.datetime):
-                    # We have time information.
-                    if dtend:
-                        # We have an end date and time.
-                        if dtstart.date() == dtend.date():
-                            # Start end end times are on the same day.
-                            # This is a common occurence, so let's format things in a
-                            # friendly way.
-                            print("Date:      %s" % format_date(dtstart))
-                            print("Starts:    %s" % format_time(dtstart))
-                            print("Ends:      %s" % format_time(dtend))
-                        else:
-                            # Start and end times are on different days.
-                            print("Starts:    %s" % format_datetime(dtstart))
-                            print("Ends:      %s" % format_datetime(dtend))
-                    else:
-                        # No end date/time.
-                        print("Starts:    %s" % format_datetime(dtstart))
-                else:
-                    # We have no time information.
-                    if dtend and dtstart != dtend:
-                        # There's an end date and it's different from the start date.
-                        print("Starts:    %s" % format_date(dtstart))
-                        print("Ends:      %s" % format_date(dtend))
-                    else:
-                        # Either starts and ends on the same day or there's no end date.
-                        print("Date:      %s" % format_date(dtstart))
-
+                handle_event_dtstart(event)
             if 'RRULE' in event:
-                rrule = event['RRULE']
-                interval = ""
-                freq = ""
-                days = ""
-                count = ""
-                until = ""
-
-                if 'INTERVAL' in rrule:
-                    try:
-                        interval_num = int(rrule['INTERVAL'][0])
-                        if interval_num == 1:
-                            interval = ''
-                        elif interval_num == 2:
-                            interval = 'other '
-                        else:
-                            interval = ordinal(interval_num) + ' '
-                    except ValueError:
-                        interval = rrule['INTERVAL'][0]
-                if 'FREQ' in rrule:
-                    if rrule['FREQ'][0] in FREQ_UNITS:
-                        freq_unit = FREQ_UNITS[rrule['FREQ'][0]]
-                        freq = 'Every %s%s' % (interval, freq_unit)
-                    else:
-                        freq_unit = rrule['FREQ'][0][:-2].lower()
-                        freq = '%s, with an interval of %s' % (rrule['FREQ'][0], rrule['INTERVAL'])
-                else:
-                    freq_unit = 'interval'
-                    freq = 'Every <unknown interval>'
-                if 'BYDAY' in rrule:
-                    if len(rrule['BYDAY']) == 1:
-                        days = 'on %s' % format_recur_byday(rrule['BYDAY'][0])
-                    elif len(rrule['BYDAY']) == 2:
-                        days = 'on %s and %s' % (
-                            format_recur_byday(rrule['BYDAY'][0]),
-                            format_recur_byday(rrule['BYDAY'][1])
-                        )
-                    elif len(rrule['BYDAY']) >= 3:
-                        days = 'on %s, and %s' % (', '.join(format_recur_byday(d) for d in rrule['BYDAY'][:-1]),
-                                                  format_recur_byday(rrule['BYDAY'][-1]))
-                if 'COUNT' in rrule:
-                    count = 'for %s %s' % (rrule['COUNT'][0], freq_unit + 's')
-                if 'UNTIL' in rrule:
-                    if isinstance(rrule['UNTIL'][0], datetime.datetime):
-                        until = "until %s" % format_datetime(rrule['UNTIL'][0])
-                    else:
-                        until = "until %s" % format_date(rrule['UNTIL'][0])
-
-                params = [x for x in [freq, days, count, until] if (x and len(x) > 0)]
-                print("Recurs:    %s" % ' '.join(params))
-
+                handle_event_rrule(event)
             if 'URL' in event:
                 print("URL:       %s" % event['URL'])
             if 'LOCATION' in event:
@@ -294,6 +305,7 @@ def main():
                         print("           %s" % format_person(attendee))
                 else:
                     print("Attendee:  %s" % format_person(event['ATTENDEE']))
+
             if 'DESCRIPTION' in event:
                 print("Description:")
                 # If the encode() call isn't there, print() will choke on anything that


### PR DESCRIPTION
I have added the functionality that mutt-ical now shows the comment of a calender event. The reason is that in the comment can be a Mail that is attached to an acceptance of an appointment.

I have also moved parts of the code in a function for better readability (including a main function). I haven't change anything on the code itself (exept the print comment stuff).